### PR TITLE
Revert "Allow atomics for fdb6"

### DIFF
--- a/fdbclient/ThreadSafeTransaction.actor.cpp
+++ b/fdbclient/ThreadSafeTransaction.actor.cpp
@@ -201,12 +201,8 @@ void ThreadSafeTransaction::makeSelfConflicting() {
 	onMainThreadVoid( [tr](){ tr->makeSelfConflicting(); }, &tr->deferredError );
 }
 
-void ThreadSafeTransaction::atomicOp( const KeyRef& key, const ValueRef& value, uint32_t operationType ) {
-	Key k = key;
-	Value v = value;
-
-	ReadYourWritesTransaction *tr = this->tr;
-	onMainThreadVoid( [tr, k, v, operationType](){ tr->atomicOp(k, v, operationType); }, &tr->deferredError );
+void ThreadSafeTransaction::atomicOp(const KeyRef& key, const ValueRef& value, uint32_t operationType) {
+	throw client_invalid_operation();
 }
 
 void ThreadSafeTransaction::set( const KeyRef& key, const ValueRef& value ) {


### PR DESCRIPTION
This reverts commit 2e6a0aa2ec010c2f66f1a2c65d50825e58e83d49.

We can't disable atomics in fdb3's ThreadSafeTransaction impl because it
breaks FuzzApiCorrectness, so this was the only place we were disabling
it. We'll just keep atomics disabled in libfdb_c.so until after the pole vault.